### PR TITLE
Uninstall everything in default namespace before rebuild cluster

### DIFF
--- a/development/support/_kube.sh
+++ b/development/support/_kube.sh
@@ -20,10 +20,27 @@ kube::_count_all_running_pods() {
 kube::wait_until_all_pods_are_running() {
     info "Waiting until all pods are status Running"
     until [[ $(kube::_count_all_running_pods) -eq $(kube::_count_all_pods) ]]; do debug "Waiting..." && sleep 3:; done
+    info "All pods are status Running"
 }
 
 kube::get_pod() {
     local namespace=$1
     local app_label=$2
     kubectl -n "${namespace}" get pod -l app="${app_label}" -o jsonpath='{.items[0].metadata.name}'
+}
+
+kube::uninstall_everything_from_namespace() {
+    local namespace=$1
+    kubectl delete --all pods --namespace="${namespace}"
+    kubectl delete --all deployments --namespace="${namespace}"
+    kubectl delete --all services --namespace="${namespace}"
+}
+
+kube::_uninstall_dashboard() {
+    kubectl delete -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml >&6 2>&1 || true
+}
+
+kube::_install_dashboard() {
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml >&6 2>&1
+    info "Run 'kubectl proxy' and then the Kubernetes dashboard can be found at http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/"
 }


### PR DESCRIPTION
Infrastructure pods are cleaned up correctly, but our own services
weren't yet (e.g. our nginx community-web service). Now `kubectl delete`
deployments, services and pods as part of the script's cleanup procedure

local-motion/product#25