### PR TITLE
Install sentry-kubernetes to send cluster errors to Sentry

### DIFF
--- a/development/_application_errors.sh
+++ b/development/_application_errors.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# shellcheck source=./support/_brew.sh
+source support/_brew.sh
+brew::install kubectl helm getsentry/tools/sentry-cli
+
+# shellcheck source=./support/_utils.sh
+source support/_utils.sh
+
+application_errors::description() {
+    echo "Application error services (Sentry and Sentry-kubernetes)"
+}
+
+application_errors::port_forwards() {
+    return
+}
+
+application_errors::uninstall() {
+    kubectl delete deployment --namespace kube-system sentry-kubernetes || true
+}
+
+application_errors::install() {
+    local sentry_dsn=$1
+    local environment= #SC2155
+
+    environment="dev-$(whoami)"
+
+    info "Deploying sentry-kubernetes pod to [kube-system] namespace, using environment ${environment} and DSN ${sentry_dsn}"
+
+    # if deployed to [default] namespace, the pod cannot access /api/v1/events?watch=true endpoint
+    # of the Kube API in [kube-system] namespace.
+    # Deploying the sentry-kubernetes deployment to [kube-system];
+    kubectl run sentry-kubernetes \
+        --namespace kube-system \
+        --image getsentry/sentry-kubernetes \
+        --env="DSN=${sentry_dsn}" \
+        --env="ENVIRONMENT=${environment}"
+}

--- a/development/_istio.sh
+++ b/development/_istio.sh
@@ -12,6 +12,10 @@ source support/_utils.sh
 source support/_kube.sh
 source _port_forward.sh
 
+istio::description() {
+    echo "Istio Pilot, Mixer and Envoy"
+}
+
 istio::port_forwards() {
     port-forward::forward istio-system jaeger 16686 16686
     port-forward::forward istio-system prometheus 19090 9090

--- a/development/_logging.sh
+++ b/development/_logging.sh
@@ -4,6 +4,10 @@
 source support/_brew.sh
 brew::install kubectl lnav stern
 
+logging::description() {
+    echo "Istio logging stack (Stern, lnav)"
+}
+
 logging::port_forwards() {
     return
 }

--- a/development/support/_brew.sh
+++ b/development/support/_brew.sh
@@ -8,8 +8,13 @@
 brew::install() {
     for program_name in "$@"
     do
-        local brew_name=${program_name}
+        local brew_name= #SC2155
         local tap_name=""
+
+        # Some brew packages use '/'. Only use last part...
+        # e.g. getsentry/tools/sentry-cli should become sentry-cli
+        # shellcheck disable=SC2001
+        brew_name=$(echo "${program_name}" | sed 's#.*/##')
 
         if [[ ${program_name} == "aws" ]]; then
             brew_name=awscli

--- a/development/support/_kube.sh
+++ b/development/support/_kube.sh
@@ -36,11 +36,11 @@ kube::uninstall_everything_from_namespace() {
     kubectl delete --all services --namespace="${namespace}"
 }
 
-kube::_uninstall_dashboard() {
+kube::uninstall_dashboard() {
     kubectl delete -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml >&6 2>&1 || true
 }
 
-kube::_install_dashboard() {
+kube::install_dashboard() {
     kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml >&6 2>&1
     info "Run 'kubectl proxy' and then the Kubernetes dashboard can be found at http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/"
 }


### PR DESCRIPTION
Installing the official incubator/sentry helm chart refuses to
start. Redis doesn't want to boot for whatever reason.

To avoid getting stuck, I'm suggesting that whoever wants to use Sentry
during development, creates its own Project in Sentry and use that to
develop.

Sentry.io comes with 10k errors and 1 user for free. That should be
enough for a month of development...

local-motion/product#14